### PR TITLE
一个小兼容处理

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -64,7 +64,6 @@ exports.create = function (options, config) {
     conns.unshift(c);
     (function heartbeat() {
       c.query(hbsql, HEARTBEAT_TIMEOUT, function (e, r) {
-        tbeat = setTimeout(heartbeat, 10 * HEARTBEAT_TIMEOUT);
         if (e) {
           o.emit('state');
           conns.shift();
@@ -79,6 +78,7 @@ exports.create = function (options, config) {
           pause = Math.min(pause + pause, 60000);
           o.emit('error', e);
         } else {
+          tbeat = setTimeout(heartbeat, 10 * HEARTBEAT_TIMEOUT);
           pause = 100;
           var t = JSON.stringify(r);
           if (t !== s) {


### PR DESCRIPTION
```
描述下情况吧，这两天跑单元测试的时候，经常会在一些奇怪的地方出现easymysql的报错，而且还是在一些没使用到easymysql模块的地方，最后找到是heartbeat造成的。
这边一开始的时候还没对easymysql的error事件做监听，跑单元测试一开始的时候heartbeat 没能在1s内没返回（可能初始化比较占资源），被判断为超时，Connection就会抛error事件，平常情况下如果程序没对EventEmitter抛出的error事件做捕获会退出，而mocha跑测试的时候不知道什么原因程序仍能继续运行，但error事件之后的代码就不执行了（本机1.7.3版本），造成Connection里超时后替换callback的行为没被执行，然后callback就被调了两次（1s没返回调了一次，1s后数据取回来了又调用了一次），pool文件中tbeat被设置了两次，导致startup方法里clearTimeout只清了后者，超时那次的settimeout还在，但那次的connection已被回收，调用query方法时报错退出。复现路径太恶心了，找了1天多才找到原因。
调整了下setTimeout的地方，只有heartbeat正常时才设置tbeat。
```
