### PR TITLE
Fix a bug in Pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -25,10 +25,6 @@ exports.create = function (options, config) {
   for (var i in options) {
     _options[i] = options[i];
   }
-  /**
-   * @ 连接数组
-   */
-  var conns = [];
 
   /**
    * @ 重连暂停
@@ -45,11 +41,6 @@ exports.create = function (options, config) {
    */
   var tbeat = null;
 
-  /**
-   * @ 空闲计时器
-   */
-  var timer = {};
-
   /* {{{ private function startup() */
   var startup = function (o) {
 
@@ -60,7 +51,7 @@ exports.create = function (options, config) {
     c.on('error', function () {});
 
     var s = '';
-    conns.unshift(c);
+    o._conns.unshift(c);
 
     function heartbeat() {
       c.query(hbsql, HEARTBEAT_TIMEOUT, function (e, r) {
@@ -85,7 +76,7 @@ exports.create = function (options, config) {
 
     function heartbeatER(e) {
       o.emit('state');
-      conns.shift();
+      o._conns.shift();
       setTimeout(function () {
         if (c) {
           c.close();
@@ -102,25 +93,21 @@ exports.create = function (options, config) {
 
   /* {{{ private function _remove() */
   var _remove = function (c, o) {
-    if (!c) {
-      return;
+    var i;
+    i = o._conns.indexOf(c);
+    if (i > 0) {
+      o._conns.splice(i, 1);
+    }
+    i = o._stack.indexOf(c);
+    if (i >= 0) {
+      o._stack.splice(i, 1);
     }
 
-    var i = conns.indexOf(c);
-
-    c.removeAllListeners('error');
+    clearTimeout(c.timer);
+    c.timer = null;
     c.close();
     c = null;
 
-    if (i < 0) {
-      return;
-    }
-
-    conns.splice(i, 1);
-    i = o._stack.indexOf(i);
-    if (i > -1) {
-      o._stack.splice(i, 1);
-    }
     _wakeup(o);
   };
   /* }}} */
@@ -149,18 +136,17 @@ exports.create = function (options, config) {
    */
   var _wakeup = function (o) {
 
-    var m = Math.min(_options.maxconnections, 1 + _options.maxconnections + o._stack.length - conns.length);
+    var m = Math.min(_options.maxconnections, 1 + _options.maxconnections + o._stack.length - o._conns.length);
     while (m && o._queue.size()) {
       var s = o._queue.shift();
       var i, c;
       do {
-        i = o._stack.pop();
-        if (i && conns[i]) {
-          c = conns[i];
-          clearTimeout(timer[i]);
-          timer[i] = null;
+        c = o._stack.pop();
+        if (c && c.timer) {
+          clearTimeout(c.timer);
+          c.timer = null;
         }
-      } while (i && !c);
+      } while (o._stack.length > 0 && !c);
 
       if (!c || !c.connected()) {
         c = Connection.create(config);
@@ -172,7 +158,7 @@ exports.create = function (options, config) {
           });
         });
 
-        conns.push(c);
+        o._conns.push(c);
       }
 
       execute(c, o, s);
@@ -183,11 +169,11 @@ exports.create = function (options, config) {
 
   /* {{{ private function release() */
   var release = function (o, c) {
-    var i = conns.indexOf(c);
+    var i = o._conns.indexOf(c);
     // XXX: we use conns[0] to heartbeat
     if (i > 0) {
-      o._stack.push(i);
-      timer[i] = setTimeout(function () {
+      o._stack.push(c);
+      c.timer = setTimeout(function () {
         _remove(c, o);
       }, _options.maxidletime);
     }
@@ -197,6 +183,17 @@ exports.create = function (options, config) {
   var Mysql = function () {
 
     Emitter.call(this);
+
+    /**
+     * @ 空闲连接
+     */
+    this._stack = [];
+
+    /**
+     * @ 连接数组
+     */
+    this._conns = [];
+
     startup(this);
 
     /**
@@ -213,18 +210,12 @@ exports.create = function (options, config) {
     this._queue.on('fill', function () {
       _wakeup(_self);
     });
-
-    /**
-     * @ 空闲连接
-     */
-    this._stack = [];
-
   };
   util.inherits(Mysql, Emitter);
 
   /* {{{ public prototype _name() */
   Mysql.prototype._name = function () {
-    return conns[0]._name;
+    return this._conns[0]._name;
   };
   /* }}} */
 


### PR DESCRIPTION
when a connection is idle timeout, it shoud be removed (we use Array.splice(i, 1) to remove a element in array ), then the _stack array and _conn array is not matched.
I changed the _stack array. it don't store the array index but the Object it self (pointer).
